### PR TITLE
INT-784 allowDiskUse true

### DIFF
--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -41,7 +41,8 @@ NativeSampler.prototype._read = function() {
   this.running = true;
 
   var options = {
-    maxTimeMS: this.maxTimeMS
+    maxTimeMS: this.maxTimeMS,
+    allowDiskUse: true
   };
 
   this.collection.count(this.query, options, function(err, count) {


### PR DESCRIPTION
only in the native sampler (aggregation framework).

Currently hard coded, but I don't think we want to ever not use this option. 