### PR TITLE
INT-1095 reservoir sampler batches _ids to use $in

### DIFF
--- a/lib/reservoir-sampler.js
+++ b/lib/reservoir-sampler.js
@@ -1,59 +1,69 @@
 var BaseSampler = require('./base-sampler');
 var inherits = require('util').inherits;
-var createReservoir = require('reservoir-stream');
 var es = require('event-stream');
+var Reservoir = require('reservoir');
 var _defaults = require('lodash.defaults');
+var _chunk = require('lodash.chunk');
+
 var debug = require('debug')('mongodb-collection-sample:reservoir-sampler');
 
+var RESERVOIR_SAMPLE_LIMIT = 10000;
+var RESERVOIR_CHUNK_SIZE = 1000;
 
 /**
- * Take an `_id` and emit the source document.
+ * Does reservoir sampling and fetches the resulting documents from the
+ * collection.
  *
- * @param {mongodb.DB} db
- * @param {String} collectionName to source from.
- * @param {Object} opts
- * @option {Object} fields to return for each document [default: `null`].
- * @return {stream.Transform}
- * @api private
+ * The query runs with a limit of `RESERVOIR_SAMPLE_LIMIT`. The reservoir
+ * then samples `size` _ids from the query result. These _ids get grouped
+ * into chunks of at most `RESERVOIR_CHUNK_SIZE`. For each chunk, a cursor
+ * is opened to fetch the actual documents. The cursor streams are combined
+ * and all the resulting documents are emitted downstream.
+
+ * @param  {mongodb.DB} db           database handle
+ * @param  {String} collectionName   the collection name to sample
+ * @param  {Number} size             how many documents should be returned
+ * @param  {Object} opts             more parameters, see below
+ * @return {Stream}                  a stream object to plug into the pipeline
  */
-function _idToDocument(db, collectionName, opts) {
+function reservoirStream(db, collectionName, size, opts) {
   opts = _defaults(opts || {}, {
-    fields: null,
-    maxTimeMS: undefined
+    chunkSize: RESERVOIR_CHUNK_SIZE
   });
-
   var collection = db.collection(collectionName);
-  return es.map(function(_id, fn) {
-    var query = _id;
-    if (!_id._id) {
-      query = {
-        _id: _id
-      };
+  var reservoir = new Reservoir(size);
+
+  var stream = es.through(
+    function write(data) {
+      // fill reservoir with ids
+      reservoir.pushSome(data);
+    },
+    function end() {
+      // split the reservoir of ids into smaller chunks
+      var chunks = _chunk(reservoir, opts.chunkSize);
+      // create cursors for chunks
+      var cursors = chunks.map(function(ids) {
+        var cursor = collection.find({
+          _id: { $in: ids }
+        });
+        if (opts.fields) {
+          cursor.fields(opts.fields);
+        }
+        if (opts.maxTimeMS) {
+          cursor.maxTimeMS(opts.maxTimeMS);
+        }
+        return cursor.stream();
+      });
+      // merge all cursors (order arbitrary) and emit docs
+      es.merge(cursors).pipe(es.through(function(doc) {
+        stream.emit('data', doc);
+      })).on('end', function() {
+        stream.emit('end');
+      });
     }
-
-    var options = {
-      fields: opts.fields,
-      maxTimeMS: opts.maxTimeMS
-    };
-
-
-    debug('findOne `%j`', query);
-
-    collection.findOne(query, options, function(err, doc) {
-      if (err) {
-        debug('error pulling document: ', err);
-        return fn(err);
-      }
-      if (!doc) {
-        debug('no document found for query `%j`.  dropping.', query);
-        return fn();
-      }
-      debug('pulled document for _id `%j`', doc._id);
-      fn(null, doc);
-    });
-  });
+  );
+  return stream;
 }
-
 
 /**
  * A readable stream of sample of documents from a collection via
@@ -65,10 +75,12 @@ function _idToDocument(db, collectionName, opts) {
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Number} size of the sample to capture [default: `5`].
  * @option {Object} fields to return for each document [default: `null`].
+ * @option {Number} chunkSize for chunked $in queries [default: `1000`].
  * @api public
  */
 function ReservoirSampler(db, collectionName, opts) {
   this.running = false;
+  this.chunkSize = opts ? opts.chunkSize : undefined;
   BaseSampler.call(this, db, collectionName, opts);
 }
 inherits(ReservoirSampler, BaseSampler);
@@ -77,7 +89,6 @@ ReservoirSampler.prototype._read = function() {
   if (this.running) {
     return;
   }
-
   this.running = true;
 
   debug('using query `%j`', this.query);
@@ -94,12 +105,16 @@ ReservoirSampler.prototype._read = function() {
         _id: 1
       },
       sort: this.sort,
-      limit: 10000
+      limit: RESERVOIR_SAMPLE_LIMIT
     })
       .stream()
-      .pipe(createReservoir(this.size))
-      .pipe(_idToDocument(this.db, this.collectionName, {
-        fields: this.fields
+      .pipe(es.map(function(obj, cb) {
+        return cb(null, obj._id);
+      }))
+      .pipe(reservoirStream(this.db, this.collectionName, this.size, {
+        chunkSize: this.chunkSize,
+        fields: this.fields,
+        maxTimeMS: this.maxTimeMS
       }))
       .on('error', this.emit.bind(this, 'error'))
       .on('data', this.push.bind(this))

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "debug": "^2.2.0",
     "event-stream": "^3.3.2",
     "get-mongodb-version": "0.0.1",
+    "lodash.chunk": "^4.0.0",
     "lodash.defaults": "^3.1.2",
-    "reservoir-stream": "0.0.2",
+    "reservoir": "^0.1.2",
     "semver": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The default batch size is `sqrt(size)`, which roughly balances number of documents in a batch with number of db requests.

- 100 docs makes 10 requests with 10 _ids
- 1000 docs makes 32 requests with 32 _ids (except last one, which is a bit smaller)
- 10000 docs makes 100 requests with 100 _ids

This feels like a good balance. We could possibly cap at the lower end and say 10 or less documents are always done in a single batch. Feedback welcome.

I'm not sure how to test the number of batches created, because I can't reach into the stream and count how often the batch function was called. Any suggestions how this could be mocked?