### PR TITLE
INT-1105 add read preference explicitly to work with secondaries.

### DIFF
--- a/lib/base-sampler.js
+++ b/lib/base-sampler.js
@@ -1,6 +1,7 @@
 var _defaults = require('lodash.defaults');
 var Readable = require('stream').Readable;
 var inherits = require('util').inherits;
+var ReadPreference = require('mongodb-read-preference');
 
 function BaseSampler(db, collectionName, opts) {
   this.db = db;
@@ -30,7 +31,10 @@ inherits(BaseSampler, Readable);
 
 Object.defineProperty(BaseSampler.prototype, 'collection', {
   get: function() {
-    return this.db.collection(this.collectionName);
+    var options = {
+      readPreference: ReadPreference.nearest
+    };
+    return this.db.collection(this.collectionName, options);
   }
 });
 

--- a/lib/reservoir-sampler.js
+++ b/lib/reservoir-sampler.js
@@ -26,11 +26,10 @@ var RESERVOIR_CHUNK_SIZE = 1000;
  * @param  {Object} opts             more parameters, see below
  * @return {Stream}                  a stream object to plug into the pipeline
  */
-function reservoirStream(db, collectionName, size, opts) {
+function reservoirStream(collection, size, opts) {
   opts = _defaults(opts || {}, {
     chunkSize: RESERVOIR_CHUNK_SIZE
   });
-  var collection = db.collection(collectionName);
   var reservoir = new Reservoir(size);
 
   var stream = es.through(
@@ -111,7 +110,7 @@ ReservoirSampler.prototype._read = function() {
       .pipe(es.map(function(obj, cb) {
         return cb(null, obj._id);
       }))
-      .pipe(reservoirStream(this.db, this.collectionName, this.size, {
+      .pipe(reservoirStream(this.collection, this.size, {
         chunkSize: this.chunkSize,
         fields: this.fields,
         maxTimeMS: this.maxTimeMS

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "check": "mongodb-js-precommit",
-    "pretest": "mongodb-runner start --topology=replicaset",
     "test": "mocha",
-    "posttest": "mongodb-runner stop --topology=replicaset",
     "ci": "npm run check && npm test",
     "fmt": "mongodb-js-fmt test/*.js bin/*.js index.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "1.0.0",
   "scripts": {
     "check": "mongodb-js-precommit",
-    "pretest": "mongodb-runner start",
+    "pretest": "mongodb-runner start --topology=replicaset",
     "test": "mocha",
-    "posttest": "mongodb-runner stop",
+    "posttest": "mongodb-runner stop --topology=replicaset",
     "ci": "npm run check && npm test",
     "fmt": "mongodb-js-fmt test/*.js bin/*.js index.js"
   },
@@ -25,6 +25,7 @@
     "get-mongodb-version": "0.0.1",
     "lodash.chunk": "^4.0.0",
     "lodash.defaults": "^3.1.2",
+    "mongodb-read-preference": "^1.0.6",
     "reservoir": "^0.1.2",
     "semver": "^5.0.3"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,13 +26,13 @@ var runnerOpts = {
 };
 
 before(function(done) {
-  this.timeout(20000);
+  this.timeout(40000);
   debug('launching local replicaset.');
   runner(runnerOpts, done);
 });
 
 after(function(done) {
-  this.timeout(10000);
+  this.timeout(20000);
   debug('stopping replicaset.');
   runner.stop(runnerOpts, done);
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,7 +26,7 @@ var runnerOpts = {
 };
 
 before(function(done) {
-  this.timeout(40000);
+  this.timeout(100000);
   debug('launching local replicaset.');
   runner(runnerOpts, done);
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,9 +3,12 @@ var assert = require('assert');
 var _range = require('lodash.range');
 var es = require('event-stream');
 var mongodb = require('mongodb');
+var ReadPreference = require('mongodb-read-preference');
 var sample = require('../');
 var ReservoirSampler = require('../lib/reservoir-sampler');
 var NativeSampler = require('../lib/native-sampler');
+
+var debug = require('debug')('mongodb-collection-sample:test');
 
 var getSampler = function(version, fn) {
   proxyquire('../lib', {
@@ -18,6 +21,19 @@ var getSampler = function(version, fn) {
 };
 
 describe('mongodb-collection-sample', function() {
+  before(function(done) {
+    // output the current version for debug purpose
+    mongodb.MongoClient.connect('mongodb://localhost:27017/test', function(err, db) {
+      assert.ifError(err);
+      db.admin().serverInfo(function(err2, info) {
+        assert.ifError(err2);
+        debug('running tests with MongoDB version %s.', info.version);
+        db.close();
+        done();
+      });
+    });
+  });
+
   describe('polyfill', function() {
     it('should use reservoir sampling if version is 3.1.5', function(done) {
       getSampler('3.1.5', function(err, src) {
@@ -196,6 +212,76 @@ describe('mongodb-collection-sample', function() {
           assert.equal(seen, 1000);
           done();
         }));
+    });
+  });
+
+  describe('topology', function() {
+    this.timeout(30000);
+
+    var dbPrim;
+    var dbSec;
+    var options = {
+      readPreference: ReadPreference.nearest
+    };
+
+    before(function(done) {
+      mongodb.MongoClient.connect('mongodb://localhost:27017/test', function(err, _dbPrim) {
+        if (err) {
+          return done(err);
+        }
+        dbPrim = _dbPrim;
+        var docs = _range(0, 100).map(function(i) {
+          return {
+            _id: 'needle_' + i,
+            is_even: i % 2
+          };
+        });
+        dbPrim.collection('haystack').insert(docs, {w: 3}, function() {
+          mongodb.MongoClient.connect('mongodb://localhost:27018/test', function(errInsert, _dbSec) {
+            if (errInsert) {
+              return done(errInsert);
+            }
+            dbSec = _dbSec;
+            dbSec.collection('haystack', options).count(function(errCount, res) {
+              assert.ifError(errCount);
+              assert.equal(res, 100);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    after(function(done) {
+      if (!dbPrim) {
+        return done();
+      }
+      dbPrim.dropCollection('haystack', function() {
+        dbPrim.close();
+        dbSec.close();
+        done();
+      });
+    });
+
+    it('should sample correctly when connected to a secondary node', function(done) {
+      var opts = {
+        size: 5,
+        query: {}
+      };
+      // Get a stream of sample documents from the collection and make sure
+      // 5 documents have been returned.
+      var count = 0;
+      var stream = sample(dbSec, 'haystack', opts);
+      stream.on('error', function(err2) {
+        done(err2);
+      });
+      stream.on('data', function() {
+        count ++;
+      });
+      stream.on('end', function() {
+        assert.equal(count, opts.size);
+        done();
+      });
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,6 +7,7 @@ var ReadPreference = require('mongodb-read-preference');
 var sample = require('../');
 var ReservoirSampler = require('../lib/reservoir-sampler');
 var NativeSampler = require('../lib/native-sampler');
+var runner = require('mongodb-runner');
 
 var debug = require('debug')('mongodb-collection-sample:test');
 
@@ -19,6 +20,22 @@ var getSampler = function(version, fn) {
     }
   }).getSampler({}, 'pets', {}, fn);
 };
+
+var runnerOpts = {
+  topology: 'replicaset'
+};
+
+before(function(done) {
+  this.timeout(20000);
+  debug('launching local replicaset.');
+  runner(runnerOpts, done);
+});
+
+after(function(done) {
+  this.timeout(10000);
+  debug('stopping replicaset.');
+  runner.stop(runnerOpts, done);
+});
 
 describe('mongodb-collection-sample', function() {
   before(function(done) {
@@ -276,7 +293,7 @@ describe('mongodb-collection-sample', function() {
         done(err2);
       });
       stream.on('data', function() {
-        count ++;
+        count++;
       });
       stream.on('end', function() {
         assert.equal(count, opts.size);


### PR DESCRIPTION
- Added read preference `nearest` on the collection (./lib/base-sampler.js). 
- Now passing same collection object to the reservoir stream function, instead of creating a new one.
- Added local test for secondaries (switched all tests to a replicaset topology, see package.json `pretest` and `posttest` hooks)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb-js/collection-sample/28)
<!-- Reviewable:end -->
