### PR TITLE
INT-1309 switch read pref to secondaryPreferred

### DIFF
--- a/lib/base-sampler.js
+++ b/lib/base-sampler.js
@@ -32,7 +32,7 @@ inherits(BaseSampler, Readable);
 Object.defineProperty(BaseSampler.prototype, 'collection', {
   get: function() {
     var options = {
-      readPreference: ReadPreference.nearest
+      readPreference: ReadPreference.secondaryPreferred
     };
     return this.db.collection(this.collectionName, options);
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -238,7 +238,7 @@ describe('mongodb-collection-sample', function() {
     var dbPrim;
     var dbSec;
     var options = {
-      readPreference: ReadPreference.nearest
+      readPreference: ReadPreference.secondaryPreferred
     };
 
     before(function(done) {


### PR DESCRIPTION
read preference `nearest` showed issues when connecting to 3.0.x mongos. This should fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/collection-sample/38)
<!-- Reviewable:end -->
