### PR TITLE
depending on count, fall back to find or reservoir.

### DIFF
--- a/lib/base-sampler.js
+++ b/lib/base-sampler.js
@@ -6,6 +6,7 @@ var ReadPreference = require('mongodb-read-preference');
 function BaseSampler(db, collectionName, opts) {
   this.db = db;
   this.collectionName = collectionName;
+  this.opts = opts;
 
   opts = _defaults(opts || {}, {
     query: {},

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -94,7 +94,6 @@ NativeSampler.prototype._read = function() {
         .on('data', this.push.bind(this))
         .on('end', this.push.bind(this, null));
     }.bind(this));
-    // set allowDiskUse only if not talking to Atlas free tier
   }.bind(this));
 };
 

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -1,4 +1,5 @@
 var BaseSampler = require('./base-sampler');
+var ReservoirSampler = require('./reservoir-sampler');
 var inherits = require('util').inherits;
 var debug = require('debug')('mongodb-collection-sample:native-sampler');
 
@@ -52,7 +53,6 @@ NativeSampler.prototype._read = function() {
 
   var options = {
     maxTimeMS: this.maxTimeMS,
-    allowDiskUse: true,
     promoteValues: this.promoteValues
   };
 
@@ -64,10 +64,37 @@ NativeSampler.prototype._read = function() {
     debug('sampling %d documents from a collection with %d documents',
       this.size, count);
 
-    this.collection.aggregate(this.pipeline, options)
+    // if we need more docs than counted, use find to return all docs
+    if (count <= this.size) {
+      return this.collection.find(this.query, {
+        fields: this.fields
+      }).on('error', this.emit.bind(this, 'error'))
+        .on('data', this.push.bind(this))
+        .on('end', this.push.bind(this, null));
+    }
+
+    // if we need more than 5% of all docs, use ReservoirSampler to avoid
+    // the blocking sort stage (SERVER-22815)
+    if (count <= this.size * 20) {
+      var reservoirSampler = new ReservoirSampler(this.db, this.collectionName, this.opts);
+      return reservoirSampler
       .on('error', this.emit.bind(this, 'error'))
       .on('data', this.push.bind(this))
       .on('end', this.push.bind(this, null));
+    }
+
+    // else, use native sampler with random index walk optimization
+    this.db.command({atlasSize: 1}, function(errAtlas) {
+      // only enable `allowDiskUse` when not connected to Atlas Free tier
+      if (errAtlas && errAtlas.message.match(/no such command/)) {
+        options.allowDiskUse = true;
+      }
+      this.collection.aggregate(this.pipeline, options)
+        .on('error', this.emit.bind(this, 'error'))
+        .on('data', this.push.bind(this))
+        .on('end', this.push.bind(this, null));
+    }.bind(this));
+    // set allowDiskUse only if not talking to Atlas free tier
   }.bind(this));
 };
 


### PR DESCRIPTION
New algorithm to determine what sampling method to use, based on `sampleSize` and collection `count`:

```js
if (sampleSize >= count) {
  // use find() to get all documents
} else if (sampleSize * 20 >= count) {
  // for more than 5% of collection, use reservoir sampling to avoid blocking sort stage
} else {
  // use native sampling with $sample
}
```

When native sampler is used, only use `allowDiskUse` option when not talking to an Atlas free tier instance.