### PR TITLE
COMPASS-809 move $project to end of pipeline

### DIFF
--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -28,19 +28,19 @@ function NativeSampler(db, collectionName, opts) {
     });
   }
 
-  // projection
-  if (this.fields && Object.keys(this.fields).length > 0) {
-    this.pipeline.push({
-      $project: this.fields
-    });
-  }
-
   // sample size
   this.pipeline.push({
     $sample: {
       size: this.size
     }
   });
+
+  // projection (last operation, only needs to be applied to sampled docs)
+  if (this.fields && Object.keys(this.fields).length > 0) {
+    this.pipeline.push({
+      $project: this.fields
+    });
+  }
 }
 inherits(NativeSampler, BaseSampler);
 


### PR DESCRIPTION
Moving the $project stage behind the $sample stage. Otherwise the following scenario can occur: 

- no filter, only project entered in query bar
- large collection (e.g. 10,000,000 documents)
- aggregation call now needs to $project on 10,000,000 documents, then sample 1000 of them, which leads to a full collection scan.

With $sample before $project, the projection only needs to be executed on 1000 documents. It is much faster than before.