### PR TITLE
Update travis.yml: Add node 6 & 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: required
 language: node_js
 node_js:
   - 6.3.1
-  - lts/boron
+  - 6
+  - 7
 script: npm run-script ci
 cache:
   directories:


### PR DESCRIPTION
Also drops the `lts/boron` alias in favour of the better supported alias `6`.