### PR TITLE
COMPASS-890: Undo special-casing `allowDiskUse` for Atlas

### DIFF
--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -53,6 +53,7 @@ NativeSampler.prototype._read = function() {
 
   var options = {
     maxTimeMS: this.maxTimeMS,
+    allowDiskUse: true,
     promoteValues: this.promoteValues
   };
 
@@ -83,17 +84,11 @@ NativeSampler.prototype._read = function() {
       .on('end', this.push.bind(this, null));
     }
 
-    // else, use native sampler with random index walk optimization
-    this.db.command({atlasSize: 1}, function(errAtlas) {
-      // only enable `allowDiskUse` when not connected to Atlas Free tier
-      if (errAtlas && errAtlas.message.match(/no such command/)) {
-        options.allowDiskUse = true;
-      }
-      this.collection.aggregate(this.pipeline, options)
-        .on('error', this.emit.bind(this, 'error'))
-        .on('data', this.push.bind(this))
-        .on('end', this.push.bind(this, null));
-    }.bind(this));
+    // else, use native sampler with random index walk optimization in the Server
+    this.collection.aggregate(this.pipeline, options)
+      .on('error', this.emit.bind(this, 'error'))
+      .on('data', this.push.bind(this))
+      .on('end', this.push.bind(this, null));
   }.bind(this));
 };
 


### PR DESCRIPTION
Atlas now allows the `allowDiskUse` aggregation option, silently ignoring it when it is not available. This commit undoes the changes introduced to work around `allowDiskUse` throwing an error in the
run-up to the free-tier launch.  `allowDiskUse` defaults to `true` for the aggregation call, just as we did before.

This will also fix COMPASS-920