### PR TITLE
COMPASS-924 workaround for NODE-966 (promoteValues in getmore)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: node_js
 node_js:
   - 6.3.1
-  - 7.4.x
+  - 7.4
 script: npm run-script ci
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 language: node_js
 node_js:
   - 6.3.1
-  - 6
-  - 7
+  - 7.4.x
 script: npm run-script ci
 cache:
   directories:
@@ -12,3 +11,4 @@ env:
   - DEBUG=mon* MONGODB_VERSION=2.6.x
   - DEBUG=mon* MONGODB_VERSION=3.0.x
   - DEBUG=mon* MONGODB_VERSION=3.2.x
+  - DEBUG=mon* MONGODB_VERSION=3.4.x

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ db.collectionName.aggregate([
 ])
 ```
 
-However, if more documents are requested than are in the collection, executes
-a regular `find()` to fetch all documents instead. If the sample size is
-above 5% of the collection count, the algorithm falls back to the reservoir
-sampling, see below.
+However, if more documents are requested than are available, the `$sample` stage
+is omitted for performance optimization. If the sample size is above 5% of the
+result set count (but less than 100%), the algorithm falls back to the reservoir
+sampling, to avoid a blocking sort stage on the server.
 
 
 #### Reservoir Sampling

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -51,8 +51,7 @@ NativeSampler.prototype._read = function() {
         .on('data', this.push.bind(this))
         .on('end', this.push.bind(this, null));
     }
-
-    // else, use native sampler with random index walk optimization
+    // else, use native sampler
 
     // add $match stage if a query was specified
     this.pipeline = [];
@@ -62,7 +61,7 @@ NativeSampler.prototype._read = function() {
       });
     }
 
-    // only add $sample stage if the collection has more
+    // only add $sample stage if the result set contains more
     // documents than requested
     if (count > this.size) {
       this.pipeline.push({
@@ -72,7 +71,7 @@ NativeSampler.prototype._read = function() {
       });
     }
 
-    // add $project stage if required
+    // add $project stage if projection (fields) was specified
     if (this.fields && Object.keys(this.fields).length > 0) {
       this.pipeline.push({
         $project: this.fields

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -17,30 +17,7 @@ var debug = require('debug')('mongodb-collection-sample:native-sampler');
  */
 function NativeSampler(db, collectionName, opts) {
   BaseSampler.call(this, db, collectionName, opts);
-
   this.running = false;
-
-  // match
-  this.pipeline = [];
-  if (Object.keys(this.query).length > 0) {
-    this.pipeline.push({
-      $match: this.query
-    });
-  }
-
-  // sample size
-  this.pipeline.push({
-    $sample: {
-      size: this.size
-    }
-  });
-
-  // projection (last operation, only needs to be applied to sampled docs)
-  if (this.fields && Object.keys(this.fields).length > 0) {
-    this.pipeline.push({
-      $project: this.fields
-    });
-  }
 }
 inherits(NativeSampler, BaseSampler);
 
@@ -65,26 +42,43 @@ NativeSampler.prototype._read = function() {
     debug('sampling %d documents from a collection with %d documents',
       this.size, count);
 
-    // if we need more docs than counted, use find to return all docs
-    if (count <= this.size) {
-      return this.collection.find(this.query, {
-        fields: this.fields
-      }).on('error', this.emit.bind(this, 'error'))
+    // if we need more than 5% of all docs (but not all of them), use
+    // ReservoirSampler to avoid the blocking sort stage (SERVER-22815)
+    if (count > this.size && count <= this.size * 20) {
+      var reservoirSampler = new ReservoirSampler(this.db, this.collectionName, this.opts);
+      return reservoirSampler
+        .on('error', this.emit.bind(this, 'error'))
         .on('data', this.push.bind(this))
         .on('end', this.push.bind(this, null));
     }
 
-    // if we need more than 5% of all docs, use ReservoirSampler to avoid
-    // the blocking sort stage (SERVER-22815)
-    if (count <= this.size * 20) {
-      var reservoirSampler = new ReservoirSampler(this.db, this.collectionName, this.opts);
-      return reservoirSampler
-      .on('error', this.emit.bind(this, 'error'))
-      .on('data', this.push.bind(this))
-      .on('end', this.push.bind(this, null));
+    // else, use native sampler with random index walk optimization
+
+    // add $match stage if a query was specified
+    this.pipeline = [];
+    if (Object.keys(this.query).length > 0) {
+      this.pipeline.push({
+        $match: this.query
+      });
     }
 
-    // else, use native sampler with random index walk optimization in the Server
+    // only add $sample stage if the collection has more
+    // documents than requested
+    if (count > this.size) {
+      this.pipeline.push({
+        $sample: {
+          size: this.size
+        }
+      });
+    }
+
+    // add $project stage if required
+    if (this.fields && Object.keys(this.fields).length > 0) {
+      this.pipeline.push({
+        $project: this.fields
+      });
+    }
+
     this.collection.aggregate(this.pipeline, options)
       .on('error', this.emit.bind(this, 'error'))
       .on('data', this.push.bind(this))

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "backoff": "^2.4.1",
     "bson": "^1.0.4",
+    "chai": "^3.5.0",
     "eslint-config-mongodb-js": "^2.2.0",
     "lodash.range": "^3.0.1",
     "mocha": "^3.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,7 @@
+/* eslint no-unused-expressions: 0 */
+
 var proxyquire = require('proxyquire');
-var assert = require('assert');
+var expect = require('chai').expect;
 var _range = require('lodash.range');
 var es = require('event-stream');
 var mongodb = require('mongodb');
@@ -43,9 +45,9 @@ describe('mongodb-collection-sample', function() {
   before(function(done) {
     // output the current version for debug purpose
     mongodb.MongoClient.connect('mongodb://localhost:31017/test', function(err, db) {
-      assert.ifError(err);
+      expect(err).to.not.exist;
       db.admin().serverInfo(function(err2, info) {
-        assert.ifError(err2);
+        expect(err2).to.not.exist;
         debug('running tests with MongoDB version %s.', info.version);
         db.close();
         done();
@@ -56,24 +58,24 @@ describe('mongodb-collection-sample', function() {
   describe('polyfill', function() {
     it('should use reservoir sampling if version is 3.1.5', function(done) {
       getSampler('3.1.5', function(err, src) {
-        assert.ifError(err);
-        assert(src instanceof ReservoirSampler);
+        expect(err).to.not.exist;
+        expect(src).to.be.an.instanceOf(ReservoirSampler);
         done();
       });
     });
 
     it('should use native sampling if version is 3.1.6', function(done) {
       getSampler('3.1.6', function(err, src) {
-        assert.ifError(err);
-        assert(src instanceof NativeSampler);
+        expect(err).to.not.exist;
+        expect(src).to.be.an.instanceOf(NativeSampler);
         done();
       });
     });
 
     it('should use native sampling if version is 3.1.7', function(done) {
       getSampler('3.1.7', function(err, src) {
-        assert.ifError(err);
-        assert(src instanceof NativeSampler);
+        expect(err).to.not.exist;
+        expect(src).to.be.an.instanceOf(NativeSampler);
         done();
       });
     });
@@ -113,8 +115,8 @@ describe('mongodb-collection-sample', function() {
 
     it('should have the test.haystack collection with 150 docs', function(done) {
       db.collection('haystack').count(function(err, res) {
-        assert.ifError(err);
-        assert.equal(res, 150);
+        expect(err).to.not.exist;
+        expect(res).to.be.equal(150);
         done();
       });
     });
@@ -125,10 +127,10 @@ describe('mongodb-collection-sample', function() {
         fields: {'is_even': 1, 'double': 1}
       })
         .pipe(es.through(function(doc) {
-          assert.ok(doc.is_even !== undefined);
-          assert.ok(doc.double !== undefined);
-          assert.equal(doc.int, undefined);
-          assert.equal(doc.long, undefined);
+          expect(doc.is_even).to.exist;
+          expect(doc.double).to.exist;
+          expect(doc.int).to.be.undefined;
+          expect(doc.long).to.be.undefined;
         }, function() {
           this.emit('end');
           done();
@@ -141,9 +143,9 @@ describe('mongodb-collection-sample', function() {
         chunkSize: 1234
       })
         .pipe(es.through(function(doc) {
-          assert.equal(typeof doc.int, 'number');
-          assert.equal(typeof doc.long, 'number');
-          assert.equal(typeof doc.double, 'number');
+          expect(doc.int).to.be.a('number');
+          expect(doc.long).to.be.a('number');
+          expect(doc.double).to.be.a('number');
           this.emit('data', doc);
         }, function() {
           this.emit('end');
@@ -159,12 +161,12 @@ describe('mongodb-collection-sample', function() {
           promoteValues: false
         })
           .pipe(es.through(function(doc) {
-            assert.equal(typeof doc.int, 'object');
-            assert.equal(doc.int._bsontype, 'Int32');
-            assert.equal(typeof doc.long, 'object');
-            assert.equal(doc.long._bsontype, 'Long');
-            assert.equal(typeof doc.double, 'object');
-            assert.equal(doc.double._bsontype, 'Double');
+            expect(doc.int).to.be.an('object');
+            expect(doc.int._bsontype).to.be.equal('Int32');
+            expect(doc.long).to.be.an('object');
+            expect(doc.long._bsontype).to.be.equal('Long');
+            expect(doc.double).to.be.an('object');
+            expect(doc.double._bsontype).to.be.equal('Double');
             this.emit('data', doc);
           }, function() {
             this.emit('end');
@@ -173,18 +175,17 @@ describe('mongodb-collection-sample', function() {
       });
       it('should not promote numeric values when asking for the full collection', function(done) {
         sample(db, 'haystack', {
-          size: 999,  // this is more than #docs, which causes a find
+          size: 999,  // this is more than #docs, which disables $sample
           chunkSize: 1234,
           promoteValues: false
         })
           .pipe(es.through(function(doc) {
-            debug('doc', doc);
-            assert.equal(typeof doc.int, 'object');
-            assert.equal(doc.int._bsontype, 'Int32');
-            assert.equal(typeof doc.long, 'object');
-            assert.equal(doc.long._bsontype, 'Long');
-            assert.equal(typeof doc.double, 'object');
-            assert.equal(doc.double._bsontype, 'Double');
+            expect(doc.int).to.be.an('object');
+            expect(doc.int._bsontype).to.be.equal('Int32');
+            expect(doc.long).to.be.an('object');
+            expect(doc.long._bsontype).to.be.equal('Long');
+            expect(doc.double).to.be.an('object');
+            expect(doc.double._bsontype).to.be.equal('Double');
             this.emit('data', doc);
           }, function() {
             this.emit('end');
@@ -224,8 +225,8 @@ describe('mongodb-collection-sample', function() {
 
     it('should use `_id: -1` as the default sort', function(done) {
       getSampler('3.1.5', function(err, src) {
-        assert.ifError(err);
-        assert.deepEqual(src.sort, {
+        expect(err).to.not.exist;
+        expect(src.sort).to.be.deep.equal({
           _id: -1
         });
         done();
@@ -234,8 +235,8 @@ describe('mongodb-collection-sample', function() {
 
     it('should have the test.haystack collection with 15000 docs', function(done) {
       db.collection('haystack').count(function(err, res) {
-        assert.ifError(err);
-        assert.equal(res, 15000);
+        expect(err).to.not.exist;
+        expect(res).to.be.equal(15000);
         done();
       });
     });
@@ -251,7 +252,7 @@ describe('mongodb-collection-sample', function() {
           this.emit('data', doc);
         }, function() {
           this.emit('end');
-          assert.equal(seen, 10000);
+          expect(seen).to.be.equal(10000);
           done();
         }));
     });
@@ -292,7 +293,7 @@ describe('mongodb-collection-sample', function() {
           this.emit('data', doc);
         }, function() {
           this.emit('end');
-          assert.equal(seen, 5);
+          expect(seen).to.be.equal(5);
           done();
         }));
     });
@@ -311,9 +312,9 @@ describe('mongodb-collection-sample', function() {
           this.emit('data', doc);
         }, function() {
           this.emit('end');
-          assert.equal(docs.filter(function(d) {
+          expect(docs.filter(function(d) {
             return d.is_even === 1;
-          }).length, options.size);
+          }).length).to.be.equal(options.size);
           done();
         }));
     });
@@ -326,7 +327,7 @@ describe('mongodb-collection-sample', function() {
           this.emit('data', doc);
         }, function() {
           this.emit('end');
-          assert.equal(seen, 5);
+          expect(seen).to.be.equal(5);
           done();
         }));
     });
@@ -343,7 +344,7 @@ describe('mongodb-collection-sample', function() {
           this.emit('data', doc);
         }, function() {
           this.emit('end');
-          assert.equal(seen, 1000);
+          expect(seen).to.be.equal(1000);
           done();
         }));
     });
@@ -377,8 +378,8 @@ describe('mongodb-collection-sample', function() {
             }
             dbSec = _dbSec;
             dbSec.collection('haystack', options).count(function(errCount, res) {
-              assert.ifError(errCount);
-              assert.equal(res, 100);
+              expect(errCount).to.not.exist;
+              expect(res).to.be.equal(100);
               done();
             });
           });
@@ -413,7 +414,7 @@ describe('mongodb-collection-sample', function() {
         count++;
       });
       stream.on('end', function() {
-        assert.equal(count, opts.size);
+        expect(count).to.be.equal(opts.size);
         done();
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,7 +32,7 @@ var runnerOpts = {
 
 var versionSupportsSample;
 
-var skipIfSampleUnsopported = function() {
+var skipIfSampleUnsupported = function() {
   if (!versionSupportsSample) {
     this.skip();
   }
@@ -122,7 +122,7 @@ describe('mongodb-collection-sample', function() {
     });
 
     context('when requesting 3% of all documents', function() {
-      before(skipIfSampleUnsopported);
+      before(skipIfSampleUnsupported);
       var opts = {
         size: 30
       };
@@ -168,7 +168,7 @@ describe('mongodb-collection-sample', function() {
       });
     });
     context('when using fields', function() {
-      before(skipIfSampleUnsopported);
+      before(skipIfSampleUnsupported);
       var opts = {
         size: 30,
         fields: {'is_even': 1, 'double': 1}
@@ -186,7 +186,7 @@ describe('mongodb-collection-sample', function() {
       });
     });
     context('when using query', function() {
-      before(skipIfSampleUnsopported);
+      before(skipIfSampleUnsupported);
       var opts = {
         size: 10,
         query: {is_even: 1}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -151,27 +151,48 @@ describe('mongodb-collection-sample', function() {
         }));
     });
 
-    it('should not promote numeric values if promoteValues is false', function(done) {
-      sample(db, 'haystack', {
-        size: 1,
-        chunkSize: 1234,
-        promoteValues: false
-      })
-        .pipe(es.through(function(doc) {
-          assert.equal(typeof doc.int, 'object');
-          assert.equal(doc.int._bsontype, 'Int32');
-          assert.equal(typeof doc.long, 'object');
-          assert.equal(doc.long._bsontype, 'Long');
-          assert.equal(typeof doc.double, 'object');
-          assert.equal(doc.double._bsontype, 'Double');
-          this.emit('data', doc);
-        }, function() {
-          this.emit('end');
-          done();
-        }));
+    context('when promoteValues is false', function() {
+      it('should not promote numeric values', function(done) {
+        sample(db, 'haystack', {
+          size: 1,
+          chunkSize: 1234,
+          promoteValues: false
+        })
+          .pipe(es.through(function(doc) {
+            assert.equal(typeof doc.int, 'object');
+            assert.equal(doc.int._bsontype, 'Int32');
+            assert.equal(typeof doc.long, 'object');
+            assert.equal(doc.long._bsontype, 'Long');
+            assert.equal(typeof doc.double, 'object');
+            assert.equal(doc.double._bsontype, 'Double');
+            this.emit('data', doc);
+          }, function() {
+            this.emit('end');
+            done();
+          }));
+      });
+      it('should not promote numeric values when asking for the full collection', function(done) {
+        sample(db, 'haystack', {
+          size: 999,  // this is more than #docs, which causes a find
+          chunkSize: 1234,
+          promoteValues: false
+        })
+          .pipe(es.through(function(doc) {
+            debug('doc', doc);
+            assert.equal(typeof doc.int, 'object');
+            assert.equal(doc.int._bsontype, 'Int32');
+            assert.equal(typeof doc.long, 'object');
+            assert.equal(doc.long._bsontype, 'Long');
+            assert.equal(typeof doc.double, 'object');
+            assert.equal(doc.double._bsontype, 'Double');
+            this.emit('data', doc);
+          }, function() {
+            this.emit('end');
+            done();
+          }));
+      });
     });
   });
-
 
   describe('Reservoir Sampler chunk sampling', function() {
     var db;


### PR DESCRIPTION
Due to a [bug](https://jira.mongodb.org/browse/NODE-966) in the node driver (promoteValues is not passed to getmore commands), we only receive unpromoted values for the first batch when using find. The last optimization of collection-sample (switching to `find()` when the full collection is requested) caused some of the numeric types to be promoted to javascript numbers when they shouldn't have been.

To work around this issue, always use the aggregation pipeline to find documents, but remove the `$sample` stage if 100% or more of the collection is requested.

Also adding more tests to confirm the pipeline is constructed correctly, and switching from assert to chai for more expressive tests.