### PR TITLE
adds an option to provide raw bson output

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Supported options that can be passed to `sample(db, coll, options)` are
 - `query`: the filter to be used, default is `{}`
 - `size`: the number of documents to sample, default is `5`
 - `fields`: the fields you want returned (projection object), default is `null`
+- `raw`: boolean to return documents as raw BSON buffers, default is `false`
 - `sort`: the sort field and direction, default is `{_id: -1}`
 - `maxTimeMS`: the maxTimeMS value after which the operation is terminated, default is `undefined`
 - `promoteValues`: boolean whether certain BSON values should be cast to native Javascript values or not. Default is `true`
@@ -97,6 +98,8 @@ However, if more documents are requested than are available, the `$sample` stage
 is omitted for performance optimization. If the sample size is above 5% of the
 result set count (but less than 100%), the algorithm falls back to the reservoir
 sampling, to avoid a blocking sort stage on the server.
+
+If the `raw` option is used, native sampling will always be used even if the sample size is above 5%.
 
 
 #### Reservoir Sampling

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ is omitted for performance optimization. If the sample size is above 5% of the
 result set count (but less than 100%), the algorithm falls back to the reservoir
 sampling, to avoid a blocking sort stage on the server.
 
-If the `raw` option is used, native sampling will always be used even if the sample size is above 5%.
-
 
 #### Reservoir Sampling
 

--- a/lib/base-sampler.js
+++ b/lib/base-sampler.js
@@ -16,7 +16,6 @@ function BaseSampler(db, collectionName, opts) {
       _id: -1
     },
     maxTimeMS: undefined,
-    cursor: {},
     promoteValues: true
   });
 
@@ -27,7 +26,6 @@ function BaseSampler(db, collectionName, opts) {
   this.sort = opts.sort;
   this.maxTimeMS = opts.maxTimeMS;
   this.promoteValues = opts.promoteValues;
-  this.cursor = opts.cursor;
 
   Readable.call(this, {
     objectMode: true

--- a/lib/base-sampler.js
+++ b/lib/base-sampler.js
@@ -16,6 +16,7 @@ function BaseSampler(db, collectionName, opts) {
       _id: -1
     },
     maxTimeMS: undefined,
+    cursor: {},
     promoteValues: true
   });
 
@@ -26,6 +27,7 @@ function BaseSampler(db, collectionName, opts) {
   this.sort = opts.sort;
   this.maxTimeMS = opts.maxTimeMS;
   this.promoteValues = opts.promoteValues;
+  this.cursor = opts.cursor;
 
   Readable.call(this, {
     objectMode: true

--- a/lib/base-sampler.js
+++ b/lib/base-sampler.js
@@ -11,6 +11,7 @@ function BaseSampler(db, collectionName, opts) {
     query: {},
     size: 5,
     fields: null,
+    raw: false,
     sort: {
       _id: -1
     },
@@ -20,6 +21,7 @@ function BaseSampler(db, collectionName, opts) {
 
   this.query = opts.query || {};
   this.size = opts.size;
+  this.raw = opts.raw;
   this.fields = opts.fields;
   this.sort = opts.sort;
   this.maxTimeMS = opts.maxTimeMS;

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,10 @@ var NativeSampler = require('./native-sampler');
  *
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Number} size of the sample to capture [default: `5`].
- * @option {Boolean} return document results as raw BSON buffers [default: `false`].
+ * @option {Boolean} raw BSON buffers to return [default: `false`].
+ * @option {Object} cursor specification when providing a raw option [default: `{}`].
+ * @option {object} cursor specification when providing a raw option. use to
+ * supply batchsize: `cursor: { batchsize: 5 }` [default: `{}`].
  */
 function getSampler(db, collectionName, opts, done) {
   db.admin().serverInfo(function(err, res) {
@@ -39,7 +42,9 @@ function getSampler(db, collectionName, opts, done) {
  * @param {Object} [opts]
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Number} size of the sample to capture [default: `5`].
- * @option {Boolean} return document results as raw BSON buffers [default: `false`].
+ * @option {Boolean} raw BSON buffers to return [default: `false`].
+ * @option {object} cursor specification when providing a raw option. use to
+ * supply batchsize: `cursor: { batchsize: 5 }` [default: `{}`].
  * @return {stream.Readable}
  * @api public
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,8 +18,6 @@ var NativeSampler = require('./native-sampler');
  * @option {Number} size of the sample to capture [default: `5`].
  * @option {Boolean} raw BSON buffers to return [default: `false`].
  * @option {Object} cursor specification when providing a raw option [default: `{}`].
- * @option {object} cursor specification when providing a raw option. use to
- * supply batchsize: `cursor: { batchsize: 5 }` [default: `{}`].
  */
 function getSampler(db, collectionName, opts, done) {
   db.admin().serverInfo(function(err, res) {
@@ -43,8 +41,6 @@ function getSampler(db, collectionName, opts, done) {
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Number} size of the sample to capture [default: `5`].
  * @option {Boolean} raw BSON buffers to return [default: `false`].
- * @option {object} cursor specification when providing a raw option. use to
- * supply batchsize: `cursor: { batchsize: 5 }` [default: `{}`].
  * @return {stream.Readable}
  * @api public
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var NativeSampler = require('./native-sampler');
  *
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Number} size of the sample to capture [default: `5`].
+ * @option {Boolean} return document results as raw BSON buffers [default: `false`].
  */
 function getSampler(db, collectionName, opts, done) {
   db.admin().serverInfo(function(err, res) {
@@ -38,6 +39,7 @@ function getSampler(db, collectionName, opts, done) {
  * @param {Object} [opts]
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Number} size of the sample to capture [default: `5`].
+ * @option {Boolean} return document results as raw BSON buffers [default: `false`].
  * @return {stream.Readable}
  * @api public
  */

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -1,6 +1,8 @@
 var BaseSampler = require('./base-sampler');
 var ReservoirSampler = require('./reservoir-sampler');
+var Transform = require('stream').Transform;
 var inherits = require('util').inherits;
+var BSON = new (require('bson'))();
 var debug = require('debug')('mongodb-collection-sample:native-sampler');
 
 /**
@@ -39,14 +41,13 @@ NativeSampler.prototype._read = function() {
     if (err) {
       return this.emit('error', err);
     }
-
-
     debug('sampling %d documents from a collection with %d documents',
       this.size, count);
 
     // if we need more than 5% of all docs (but not all of them), use
-    // ReservoirSampler to avoid the blocking sort stage (SERVER-22815)
-    if (count > this.size && count <= this.size * 20) {
+    // ReservoirSampler to avoid the blocking sort stage (SERVER-22815).
+    // if need raw output, always do native sampling
+    if (!this.raw && count > this.size && count <= this.size * 20) {
       var reservoirSampler = new ReservoirSampler(this.db, this.collectionName, this.opts);
       return reservoirSampler
         .on('error', this.emit.bind(this, 'error'))
@@ -82,12 +83,37 @@ NativeSampler.prototype._read = function() {
 
     options.raw = this.raw;
     options.cursor = this.cursor;
+    options.batchSize = this.size;
 
-    this.collection.aggregate(this.pipeline, options)
-      .on('error', this.emit.bind(this, 'error'))
-      .on('data', this.push.bind(this))
-      .on('end', this.push.bind(this, null));
+    var cursor = this.collection.aggregate(this.pipeline, options);
+
+    if (options.raw) {
+      cursor.pipe(rawChunker)
+        .on('error', this.emit.bind(this, 'error'))
+        .on('data', this.push.bind(this))
+        .on('end', this.push.bind(this, null));
+    } else {
+      cursor
+        .on('error', this.emit.bind(this, 'error'))
+        .on('data', this.push.bind(this))
+        .on('end', this.push.bind(this, null));
+    }
   }.bind(this));
 };
+
+// split up incoming raw bytes and return documents one by one; NODE-1906
+var rawChunker = new Transform({
+  readableObjectMode: true,
+  writableObjectMode: true,
+
+  transform(chunk, encoding, callback) {
+    var response = BSON.deserialize(chunk);
+    response.cursor.firstBatch.forEach(doc => {
+      this.push(BSON.serialize(doc));
+    });
+
+    callback();
+  }
+});
 
 module.exports = NativeSampler;

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -13,6 +13,7 @@ var debug = require('debug')('mongodb-collection-sample:native-sampler');
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Array} fields to only return certain fields [default: null]
  * @option {Number} size of the sample to capture [default: `5`].
+ * @option {Boolean} return document results as raw BSON buffers [default: `false`].
  * @api public
  */
 function NativeSampler(db, collectionName, opts) {
@@ -31,7 +32,8 @@ NativeSampler.prototype._read = function() {
   var options = {
     maxTimeMS: this.maxTimeMS,
     allowDiskUse: true,
-    promoteValues: this.promoteValues
+    promoteValues: this.promoteValues,
+    raw: this.raw
   };
 
   this.collection.countDocuments(this.query, options, function(err, count) {

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -1,8 +1,7 @@
 var BaseSampler = require('./base-sampler');
+var rawTransform = require('./raw-transform');
 var ReservoirSampler = require('./reservoir-sampler');
-var Transform = require('stream').Transform;
 var inherits = require('util').inherits;
-var BSON = new (require('bson'))();
 var debug = require('debug')('mongodb-collection-sample:native-sampler');
 
 /**
@@ -47,7 +46,7 @@ NativeSampler.prototype._read = function() {
     // if we need more than 5% of all docs (but not all of them), use
     // ReservoirSampler to avoid the blocking sort stage (SERVER-22815).
     // if need raw output, always do native sampling
-    if (!this.raw && count > this.size && count <= this.size * 20) {
+    if (count > this.size && count <= this.size * 20) {
       var reservoirSampler = new ReservoirSampler(this.db, this.collectionName, this.opts);
       return reservoirSampler
         .on('error', this.emit.bind(this, 'error'))
@@ -87,33 +86,11 @@ NativeSampler.prototype._read = function() {
 
     var cursor = this.collection.aggregate(this.pipeline, options);
 
-    if (options.raw) {
-      cursor.pipe(rawChunker)
-        .on('error', this.emit.bind(this, 'error'))
-        .on('data', this.push.bind(this))
-        .on('end', this.push.bind(this, null));
-    } else {
-      cursor
-        .on('error', this.emit.bind(this, 'error'))
-        .on('data', this.push.bind(this))
-        .on('end', this.push.bind(this, null));
-    }
+    cursor.pipe(rawTransform(this.raw))
+      .on('error', this.emit.bind(this, 'error'))
+      .on('data', this.push.bind(this))
+      .on('end', this.push.bind(this, null));
   }.bind(this));
 };
-
-// split up incoming raw bytes and return documents one by one; NODE-1906
-var rawChunker = new Transform({
-  readableObjectMode: true,
-  writableObjectMode: true,
-
-  transform(chunk, encoding, callback) {
-    var response = BSON.deserialize(chunk);
-    response.cursor.firstBatch.forEach(doc => {
-      this.push(BSON.serialize(doc));
-    });
-
-    callback();
-  }
-});
 
 module.exports = NativeSampler;

--- a/lib/native-sampler.js
+++ b/lib/native-sampler.js
@@ -32,14 +32,14 @@ NativeSampler.prototype._read = function() {
   var options = {
     maxTimeMS: this.maxTimeMS,
     allowDiskUse: true,
-    promoteValues: this.promoteValues,
-    raw: this.raw
+    promoteValues: this.promoteValues
   };
 
   this.collection.countDocuments(this.query, options, function(err, count) {
     if (err) {
       return this.emit('error', err);
     }
+
 
     debug('sampling %d documents from a collection with %d documents',
       this.size, count);
@@ -79,6 +79,9 @@ NativeSampler.prototype._read = function() {
         $project: this.fields
       });
     }
+
+    options.raw = this.raw;
+    options.cursor = this.cursor;
 
     this.collection.aggregate(this.pipeline, options)
       .on('error', this.emit.bind(this, 'error'))

--- a/lib/raw-transform.js
+++ b/lib/raw-transform.js
@@ -1,0 +1,25 @@
+var Transform = require('stream').Transform;
+var BSON = new (require('bson'))();
+
+module.exports = function rawTransform(raw) {
+  // split up incoming raw bytes and return documents one by one; NODE-1906
+  // this is only necessary for native sampler
+  function transform(chunk, encoding, cb) {
+    // only transform for raw bytes
+    if (raw) {
+      var response = BSON.deserialize(chunk);
+      response.cursor.firstBatch.forEach(function(doc) {
+        this.push(BSON.serialize(doc));
+      }.bind(this));
+      return cb();
+    }
+    // otherwise go back to the main stream
+    return cb(null, chunk);
+  }
+
+  return new Transform({
+    readableObjectMode: true,
+    writableObjectMode: true,
+    transform: transform
+  });
+};

--- a/lib/reservoir-sampler.js
+++ b/lib/reservoir-sampler.js
@@ -26,6 +26,7 @@ var RESERVOIR_CHUNK_SIZE = 1000;
  * @option {Object} query to refine possible samples [default: `{}`].
  * @option {Number} size of the sample to capture [default: `5`].
  * @option {Object} fields to return for each document [default: `null`].
+ * @option {Boolean} return document results as raw BSON buffers [default: `false`].
  * @option {Number} chunkSize For chunked $in queries [default: `1000`].
  * @return {stream.Readable}
  * @api private
@@ -47,7 +48,7 @@ function reservoirStream(collection, size, opts) {
       var chunks = _chunk(reservoir, opts.chunkSize);
       // create cursors for chunks
       var cursors = chunks.map(function(ids) {
-        var cursor = collection.find({ _id: { $in: ids }}, { promoteValues: opts.promoteValues });
+        var cursor = collection.find({ _id: { $in: ids }}, { promoteValues: opts.promoteValues, raw: opts.raw });
         if (opts.fields) {
           cursor.project(opts.fields);
         }
@@ -115,6 +116,7 @@ ReservoirSampler.prototype._read = function() {
         chunkSize: this.chunkSize,
         fields: this.fields,
         maxTimeMS: this.maxTimeMS,
+        raw: this.raw,
         promoteValues: this.promoteValues
       }))
       .on('error', this.emit.bind(this, 'error'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1082,7 +1082,8 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "optional": true
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -2856,7 +2857,8 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "optional": true
     },
     "lodash.assignin": {
       "version": "4.2.0",
@@ -3367,7 +3369,7 @@
       "integrity": "sha512-4Mk7wALKG40Ba+Twej5sDiPtJHxV2GzZkAHnAWz/RCN7PcKyphCVQqlu6rGfUueLLYW2H5dKliAdyCzG6jRy8A==",
       "optional": true,
       "requires": {
-        "bson": "github:mongodb/js-bson#88f66d0c31dd8d10a981ce4599145aa12c904afd"
+        "bson": "bson@github:mongodb/js-bson#88f66d0c31dd8d10a981ce4599145aa12c904afd"
       },
       "dependencies": {
         "bson": {
@@ -3542,7 +3544,7 @@
         "mkdirp": "^0.5.1",
         "mongodb": "^3.1.9",
         "mongodb-dbpath": "^0.0.1",
-        "mongodb-tools": "github:mongodb-js/mongodb-tools#194bdd6ac7922f8dcf3853de1aece0b0fdda93cf",
+        "mongodb-tools": "mongodb-tools@github:mongodb-js/mongodb-tools#194bdd6ac7922f8dcf3853de1aece0b0fdda93cf",
         "mongodb-version-manager": "^1.3.0",
         "untildify": "^3.0.0",
         "which": "^1.2.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -748,7 +748,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3369,12 +3369,12 @@
       "integrity": "sha512-4Mk7wALKG40Ba+Twej5sDiPtJHxV2GzZkAHnAWz/RCN7PcKyphCVQqlu6rGfUueLLYW2H5dKliAdyCzG6jRy8A==",
       "optional": true,
       "requires": {
-        "bson": "bson@github:mongodb/js-bson#88f66d0c31dd8d10a981ce4599145aa12c904afd"
+        "bson": "github:mongodb/js-bson#2.0.0"
       },
       "dependencies": {
         "bson": {
-          "version": "github:mongodb/js-bson#88f66d0c31dd8d10a981ce4599145aa12c904afd",
-          "from": "bson@github:mongodb/js-bson#88f66d0c31dd8d10a981ce4599145aa12c904afd",
+          "version": "github:mongodb/js-bson#b75bcf071a27c8374a8095884560bdae0c65929b",
+          "from": "github:mongodb/js-bson#2.0.0",
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "mongodb-js-precommit",
     "pretest": "mongodb-runner start --port=27018",
     "posttest": "mongodb-runner stop --port=27018",
-    "test": "mocha",
+    "test": "mocha --exit",
     "ci": "npm run check && npm test",
     "fmt": "mongodb-js-fmt test/*.js bin/*.js index.js"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -180,7 +180,7 @@ describe('mongodb-collection-sample', function() {
     });
 
     it('should return raw bson buffer when requested', function(done) {
-      sample(db, 'haystack', { size: 10, raw: true })
+      sample(db, 'haystack', { size: 2, raw: true })
         .pipe(es.through(function(doc) {
           expect(Buffer.isBuffer(doc)).to.be.true;
         }, function() {
@@ -199,7 +199,7 @@ describe('mongodb-collection-sample', function() {
       var db;
 
       before(function(done) {
-        this.timeout(300000);
+        this.timeout(3000000);
         mongodb.MongoClient.connect('mongodb://localhost:27018/test', { useNewUrlParser: true }, function(err, client) {
           if (err) {
             return done(err);
@@ -227,7 +227,7 @@ describe('mongodb-collection-sample', function() {
       });
 
       it('buffer does not overflow', function(done) {
-        sample(db, 'haystack', { size: 1000000, raw: true })
+        sample(db, 'haystack', { size: 100000, raw: true })
           .pipe(es.through(function(doc) {
             expect(Buffer.isBuffer(doc)).to.be.true;
           }, function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -193,48 +193,50 @@ describe('mongodb-collection-sample', function() {
   // This test creates 2mil documents and samples 1mil of those to make sure
   // buffer doesn't overflow. Only creating 2mil documents, since any more
   // causes v8 to run out memory in heap.
-  // FYI: takes a long time to run.
-  describe('raw buffer over a large set of documents', function() {
-    var db;
+  // FYI: takes a while, so will only run with `test=BIG_SAMPLE npm run test`
+  if (process.env.test === 'BIG_SAMPLE') {
+    describe('raw buffer over a large set of documents', function() {
+      var db;
 
-    before(function(done) {
-      this.timeout(300000);
-      mongodb.MongoClient.connect('mongodb://localhost:27018/test', { useNewUrlParser: true }, function(err, client) {
-        if (err) {
-          return done(err);
-        }
-        db = client.db('test');
+      before(function(done) {
+        this.timeout(300000);
+        mongodb.MongoClient.connect('mongodb://localhost:27018/test', { useNewUrlParser: true }, function(err, client) {
+          if (err) {
+            return done(err);
+          }
+          db = client.db('test');
 
-        var docs = _range(2000000).map(function(i) {
-          return {
-            _id: 'needle_' + i,
-            is_even: i % 2,
-            long: bson.Long.fromString('1234567890'),
-            double: 0.23456,
-            int: 1234
-          };
+          var docs = _range(2000000).map(function(i) {
+            return {
+              _id: 'needle_' + i,
+              is_even: i % 2,
+              long: bson.Long.fromString('1234567890'),
+              double: 0.23456,
+              int: 1234
+            };
+          });
+          db.collection('haystack').insertMany(docs, done);
         });
-        db.collection('haystack').insertMany(docs, done);
+      });
+
+      after(function(done) {
+        if (!db) {
+          return done();
+        }
+        db.dropCollection('haystack', done);
+      });
+
+      it('buffer does not overflow', function(done) {
+        sample(db, 'haystack', { size: 1000000, raw: true })
+          .pipe(es.through(function(doc) {
+            expect(Buffer.isBuffer(doc)).to.be.true;
+          }, function() {
+            this.emit('end');
+            done();
+          }));
       });
     });
-
-    after(function(done) {
-      if (!db) {
-        return done();
-      }
-      db.dropCollection('haystack', done);
-    });
-
-    it('buffer does not overflow', function(done) {
-      sample(db, 'haystack', { size: 1000000, raw: true })
-        .pipe(es.through(function(doc) {
-          expect(Buffer.isBuffer(doc)).to.be.true;
-        }, function() {
-          this.emit('end');
-          done();
-        }));
-    });
-  });
+  }
 
   describe('promoteValues', function() {
     var db;


### PR DESCRIPTION
This allows for both `collection.find` and `collection.aggregate` to accept `raw` option and give us back raw bson to work with. `raw` defaults to false. 